### PR TITLE
Rewired to recommended API

### DIFF
--- a/lib/markdown-preview-plus-opener.coffee
+++ b/lib/markdown-preview-plus-opener.coffee
@@ -17,18 +17,17 @@ module.exports = MarkdownPreviewPlusOpener =
         console.log 'markdown-preview-plus-opener-view: markdown-preview-plus package not found'
         return
 
-    atom.workspace.onDidOpen(@subscribePane)
+    atom.workspace.observeTextEditors(@subscribeEditor)
 
-  subscribePane: (event) ->
-    suffix = event?.uri?.match(/(\w*)$/)[1]
+  subscribeEditor: (editor) ->
+    suffix = editor?.getPath()?.match(/(\w*)$/)[1]
     if suffix in atom.config.get('markdown-preview-plus-opener.suffixes')
-      previewUrl = "markdown-preview-plus://editor/#{event.item.id}"
+      previewUrl = "markdown-preview-plus://editor/#{editor.id}"
       previewPane = atom.workspace.paneForURI(previewUrl)
-      workspaceView = atom.views.getView(atom.workspace)
       if not previewPane
-        atom.commands.dispatch workspaceView, 'markdown-preview-plus:toggle'
+        atom.commands.dispatch editor.element, 'markdown-preview-plus:toggle'
         if atom.config.get('markdown-preview-plus-opener.closePreviewWhenClosingEditor')
-          event.item.onDidDestroy ->
+          editor.onDidDestroy ->
             for pane in atom.workspace.getPanes()
               for item in pane.items when item.getURI() is previewUrl
                 pane.destroyItem(item)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "markdown-preview-plus-opener",
   "main": "./lib/markdown-preview-plus-opener",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Opens the markdown-preview-plus pane automatically when a markdown file is opened. Forked from plafue's markdown-preview-opener. They really did all the work.",
   "repository": "https://github.com/nick-f/markdown-preview-plus-opener",
   "license": "MIT",


### PR DESCRIPTION
* The canonical API for watching editor opens is `observeTextEditors`
* Dispatching the preview command to the view has stopped working
* Dispatching the command to the editor element works properly